### PR TITLE
Fix for a security vulnerability in rexml

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,7 +153,7 @@ GEM
       declarative-option (< 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
-    rexml (3.2.4)
+    rexml (3.2.5)
     rouge (2.0.7)
     ruby2_keywords (0.0.4)
     rubyzip (2.3.0)
@@ -199,4 +199,4 @@ DEPENDENCIES
   fastlane
 
 BUNDLED WITH
-   2.1.2
+   2.2.16


### PR DESCRIPTION
This PR fixes a security vulnerability in rexml. Read more here: https://www.ruby-lang.org/en/news/2021/04/05/xml-round-trip-vulnerability-in-rexml-cve-2021-28965/